### PR TITLE
pyproject: license classifiers are deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,15 @@ dependencies = [
     "structlog      == 24.4.0",
     "tqdm           == 4.66.5",
     "paho-mqtt      >= 2.1.0",
+    "pygame         >= 2.6.1",
 ]
 description = "Run Your Own Robot Swarm Testbed."
 readme = "README.md"
-license = { text="BSD" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files 